### PR TITLE
Re-export BcryptResult and BcryptError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use rand::{Rng, OsRng};
 mod b64;
 mod errors;
 
-use errors::{BcryptResult, BcryptError};
+pub use errors::{BcryptResult, BcryptError};
 
 
 // Cost constants


### PR DESCRIPTION
Without Re-exporting you cannot match against it's error variants.

E.g.
```
use bcrypt::{BcryptError, hash, DEFAULT_COST};
let password = "test";
match hash(password, DEFAULT_COST) {
    Ok(hashed) => println!("{}", hashed),
    Err(BcryptError::Io(x)) => println!("Io Error: {}", x),
    Err(BcryptError::InvalidCost) => unreachable!(),
    Err(_) => panic!(),
}
```