### PR TITLE
Implement Error Trait for BcryptError

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,6 @@
+use std::error;
+use std::fmt;
 use std::io;
-
 
 /// Library generic result type.
 pub type BcryptResult<T> = Result<T, BcryptError>;
@@ -9,8 +10,8 @@ pub type BcryptResult<T> = Result<T, BcryptError>;
 /// passwords
 pub enum BcryptError {
     Io(io::Error),
-    InvalidCost,
-    InvalidPrefix
+    InvalidCost(u32),
+    InvalidPrefix(String),
 }
 
 macro_rules! impl_from_error {
@@ -22,3 +23,34 @@ macro_rules! impl_from_error {
 }
 
 impl_from_error!(io::Error, BcryptError::Io);
+
+
+impl fmt::Display for BcryptError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            BcryptError::Io(ref err) => write!(f, "IO error: {}", err),
+            BcryptError::InvalidCost(ref cost_supplied) => {
+                write!(f, "Invalid Cost: {}", cost_supplied)
+            }
+            BcryptError::InvalidPrefix(ref prefix) => write!(f, "Invalid Prefix: {}", prefix),
+        }
+    }
+}
+
+impl error::Error for BcryptError {
+    fn description(&self) -> &str {
+        match *self {
+            BcryptError::Io(ref err) => err.description(),
+            BcryptError::InvalidCost(_) => "Invalid Cost",
+            BcryptError::InvalidPrefix(_) => "Invalid Prefix",
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            BcryptError::Io(ref err) => Some(err),
+            BcryptError::InvalidCost(_) => None,
+            BcryptError::InvalidPrefix(_) => None,
+        }
+    }
+}


### PR DESCRIPTION
Questions to be answered:

- Should the error expose the invalid options supplied by the user?
- Is the `.to_string()` call acceptable on line 93 of lib.rs