### PR TITLE
update dependencies. replace byte_tools with byteorder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/Keats/rust-bcrypt"
 keywords = ["bcrypt", "password", "web", "hash"]
 
 [dependencies]
-blowfish = { version = "0.3", features = ["bcrypt"] }
+blowfish = { version = "0.4", features = ["bcrypt"] }
 rand = "0.6"
 lazy_static = "1"
-base64 = "0.9"
-byte-tools = "0.2"
+base64 = "0.10"
+byteorder = "1"

--- a/src/bcrypt.rs
+++ b/src/bcrypt.rs
@@ -1,5 +1,5 @@
 use blowfish::Blowfish;
-use byte_tools::write_u32_be;
+use byteorder::{BE, ByteOrder};
 
 fn setup(cost: u32, salt: &[u8], key: &[u8]) -> Blowfish {
     assert!(cost < 32);
@@ -31,7 +31,7 @@ pub fn bcrypt(cost: u32, salt: &[u8], password: &[u8], output: &mut [u8]) {
             ctext[i] = l;
             ctext[i + 1] = r;
         }
-        write_u32_be(&mut output[i * 4..(i + 1) * 4], ctext[i]);
-        write_u32_be(&mut output[(i + 1) * 4..(i + 2) * 4], ctext[i + 1]);
+        BE::write_u32(&mut output[i * 4..(i + 1) * 4], ctext[i]);
+        BE::write_u32(&mut output[(i + 1) * 4..(i + 2) * 4], ctext[i + 1]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,11 @@
 extern crate lazy_static;
 extern crate base64;
 extern crate blowfish;
-extern crate byte_tools;
+extern crate byteorder;
 extern crate rand;
 
 use std::convert::AsRef;
-use rand::{RngCore, OsRng};
+use rand::{RngCore, rngs::OsRng};
 
 mod b64;
 mod errors;


### PR DESCRIPTION
`byte_tools` [doesn't have](https://github.com/RustCrypto/utils/commit/9b3ac7f91add1730b79cf29bccac2c3daccee563) required functions anymore. So, it is replaced by `byteorder`.