### PR TITLE
Expose bcrypt function to the public.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod errors;
 mod bcrypt;
 
 pub use errors::{BcryptError, BcryptResult};
+pub use bcrypt::bcrypt;
 
 // Cost constants
 const MIN_COST: u32 = 4;


### PR DESCRIPTION
Hi,

I would like to use the [function](https://github.com/Keats/rust-bcrypt/blob/bf042b361aee3202033a9aeaf664558a11f77cd3/src/bcrypt.rs#L17) that executes the bcrypt algorithm. The function itself is `pub` in the code, but does not get exposed out of the crate. 

I think there it can be exported along with `DEFAULT_COST`, `hash` and `verify`... What do you think?