### PR TITLE
Improve interop with consumers

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,7 +6,7 @@ use rand;
 /// Library generic result type.
 pub type BcryptResult<T> = Result<T, BcryptError>;
 
-#[derive(Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 /// All the errors we can encounter while hashing/verifying
 /// passwords
 pub enum BcryptError {


### PR DESCRIPTION
Following Rust API guidelines: https://rust-lang-nursery.github.io/api-guidelines/interoperability.html

As a personal note, I can't use BcryptError as a "cause" with Failure unless it implements PartialEq as it means I can't implement PartialEq on my own errors which I use in tests.