### PR TITLE
Implement source instead of cause in BCryptError

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -70,7 +70,7 @@ impl error::Error for BcryptError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             BcryptError::Io(ref err) => Some(err),
             BcryptError::InvalidCost(_)


### PR DESCRIPTION
`cause` is deprecated and has a default implementation of calling `source` method.