### PR TITLE
Make format_for_version(...) public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ impl HashParts {
     }
 
     /// Creates the bcrypt hash string from all its part, allowing to customize the version.
-    fn format_for_version(&self, version: Version) -> String {
+    pub fn format_for_version(&self, version: Version) -> String {
         // Cost need to have a length of 2 so padding with a 0 if cost < 10
         format!("${}${:02}${}{}", version, self.cost, self.salt, self.hash)
     }


### PR DESCRIPTION
I need the possibility to generate a specific version of a bcrypt hash.

`format_for_version` is exactly what I need, but it is not callable from the outside, because it is not public.

This change request just makes it public.

Perhaps you can merge it into the main repo.

Thanks and Regards,

Thorsten