### PR TITLE
Forbid unsafe code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # bcrypt
 
+[![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 [![Build Status](https://travis-ci.org/Keats/rust-bcrypt.svg)](https://travis-ci.org/Keats/rust-bcrypt)
 [![Documentation](https://docs.rs/bcrypt/badge.svg)](https://docs.rs/bcrypt)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 //! Easily hash and verify passwords using bcrypt
+#![forbid(unsafe_code)]
+
 use rand::{rngs::OsRng, RngCore};
 use std::convert::AsRef;
 use std::fmt;


### PR DESCRIPTION
`#![forbid(unsafe_code)]` annotation makes rustc abort compilation if
there are any unsafe blocks in the crate, and exceptions cannot be made
with allow/warn annotations.

Also add a badge on README.md to advertise the complete safety of
rust-bcrypt.