### PR TITLE
Use constant-time comparison in verify()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,13 +185,12 @@ pub fn verify<P: AsRef<[u8]>>(password: P, hash: &str) -> BcryptResult<bool> {
         return Ok(false);
     }
 
+    let mut diff = 0;
     for (a, b) in source_decoded.into_iter().zip(generated_decoded) {
-        if a != b {
-            return Ok(false);
-        }
+        diff |= a ^ b;
     }
 
-    Ok(true)
+    Ok(diff == 0)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I'm not sure if this is necessary for hashsums but it's not a bad habit when working with secrets.

OpenBSD does this: [bcrypt.c](https://github.com/openbsd/src/blob/e88cbbaaab02fa72ee6c643b235764c571e837e7/lib/libc/crypt/bcrypt.c#L221-L236), [timingsafe_bcmp.c](https://github.com/openbsd/src/blob/e88cbbaaab02fa72ee6c643b235764c571e837e7/lib/libc/string/timingsafe_bcmp.c#L20-L29).

So does py_bcrypt: [\_\_init\_\_.py](https://github.com/pyca/bcrypt/blob/2e6287ce2311d96b792cbc0acc311c7e8ff980db/src/bcrypt/__init__.py#L112).