### PR TITLE
Use Vec::with_capacity() to prevent an unnecessary reallocation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ fn _hash_password(password: &[u8], cost: u32, salt: &[u8]) -> BcryptResult<HashP
     // Output is 24
     let mut output = [0u8; 24];
     // Passwords need to be null terminated
-    let mut vec: Vec<u8> = Vec::new();
+    let mut vec = Vec::with_capacity(password.len() + 1);
     vec.extend_from_slice(password);
     vec.push(0);
     // We only consider the first 72 chars; truncate if necessary.


### PR DESCRIPTION
`Vec::extend_from_slice()` [calls `self.reserve()` under the hood](https://doc.rust-lang.org/1.43.0/src/alloc/vec.rs.html#2114-2127), which, according to the documentation, "may reserve more space to avoid frequent reallocations" but that's not a guarantee. `RawVec::reserve()` appears [to either double the current capacity or set it to current + required](https://doc.rust-lang.org/1.43.0/src/alloc/raw_vec.rs.html#408-423).