### PR TITLE
Add no_std support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,16 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        rust: [1.34.0, stable]
+        rust: [1.34.0, 1.36.0, stable]
+
+        include:
+          - rust: 1.34.0
+            test_no_std: false
+          - rust: 1.36.0
+            test_no_std: true
+          - rust: stable
+            test_no_std: true
+      fail-fast: false
 
     steps:
     - name: Checkout repository
@@ -22,7 +31,18 @@ jobs:
         toolchain: ${{ matrix.rust }}
         profile: minimal
         override: true
+        components: rustfmt
 
     - name: Run tests
       run: |
         cargo test
+
+    - name: Run tests using no_std
+      if: matrix.test_no_std == true
+      run: |
+        cargo test --no-default-features --features alloc
+
+    - name: Check formatting
+      if: matrix.rust == 'stable'
+      run: |
+        cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,18 @@ repository = "https://github.com/Keats/rust-bcrypt"
 keywords = ["bcrypt", "password", "web", "hash"]
 edition = "2018"
 
+[features]
+default = ["std"]
+std = ["base64/std", "byteorder/std"]
+alloc = ["base64/alloc"]
+wasm-bindgen = ["getrandom/wasm-bindgen"]
+stdweb = ["getrandom/stdweb"]
+
 [dependencies]
 blowfish = { version = "0.4", features = ["bcrypt"] }
-rand = "0.7"
-base64 = "0.12.1"
-byteorder = "1"
+getrandom = "0.1"
+base64 = { version = "0.12.1", default-features = false }
+byteorder = { version = "1", default-features = false }
 
 [dev-dependencies]
 quickcheck = "0.9.0"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add the following to Cargo.toml:
 bcrypt = "0.7"
 ```
 
-The minimum Rust version is 1.34.0
+The minimum Rust version is 1.34.0 (or 1.36.0 when using `alloc` instead of `std`).
 
 ## Usage
 The crate makes 3 things public: `DEFAULT_COST`, `hash`, `verify`.
@@ -29,7 +29,7 @@ The cost needs to be an integer between 4 and 31 (see benchmarks to have an idea
 
 ## Benchmarks
 Speed depends on the cost used: the highest the slowest.
-Here are some benchmarks on my 4 years old laptop to give you some ideas on the cost/speed ratio. 
+Here are some benchmarks on my 4 years old laptop to give you some ideas on the cost/speed ratio.
 Note that I don't go above 14 as it takes too long.
 
 ```

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,10 @@
-use rand;
+use alloc::string::String;
+use core::fmt;
+use getrandom;
+
+#[cfg(feature = "std")]
 use std::error;
-use std::fmt;
+#[cfg(feature = "std")]
 use std::io;
 
 /// Library generic result type.
@@ -10,6 +14,7 @@ pub type BcryptResult<T> = Result<T, BcryptError>;
 /// All the errors we can encounter while hashing/verifying
 /// passwords
 pub enum BcryptError {
+    #[cfg(feature = "std")]
     Io(io::Error),
     CostNotAllowed(u32),
     InvalidPassword,
@@ -17,7 +22,7 @@ pub enum BcryptError {
     InvalidPrefix(String),
     InvalidHash(String),
     InvalidBase64(base64::DecodeError),
-    Rand(rand::Error),
+    Rand(getrandom::Error),
 }
 
 macro_rules! impl_from_error {
@@ -31,12 +36,14 @@ macro_rules! impl_from_error {
 }
 
 impl_from_error!(base64::DecodeError, BcryptError::InvalidBase64);
+#[cfg(feature = "std")]
 impl_from_error!(io::Error, BcryptError::Io);
-impl_from_error!(rand::Error, BcryptError::Rand);
+impl_from_error!(getrandom::Error, BcryptError::Rand);
 
 impl fmt::Display for BcryptError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            #[cfg(feature = "std")]
             BcryptError::Io(ref err) => write!(f, "IO error: {}", err),
             BcryptError::InvalidCost(ref cost) => write!(f, "Invalid Cost: {}", cost),
             BcryptError::CostNotAllowed(ref cost) => write!(
@@ -55,6 +62,7 @@ impl fmt::Display for BcryptError {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for BcryptError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {


### PR DESCRIPTION
I also replaced `rand` with a smaller dependency, `getrandom`, because that's pretty much what `OsRng::fill_bytes` is: https://github.com/rust-random/rand/blob/bf8b5a98ac95da19953f0b3b0f6da6ec8eda940b/rand_core/src/os.rs#L66-L69.

`OsRng::fill_bytes`'s return value was previously ignored, I assume that's not intended, so I changed that.