### PR TITLE
update blowfish dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        rust: [1.36.0, stable]
+        rust: [1.41.1, stable]
 
         include:
-          - rust: 1.36.0
+          - rust: 1.41.1
             test_no_std: false
-          - rust: 1.36.0
+          - rust: 1.41.1
             test_no_std: true
           - rust: stable
             test_no_std: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcrypt"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Vincent Prouillet <hello@prouilletvincent.com>"]
 license = "MIT"
 readme = "README.md"
@@ -17,7 +17,7 @@ alloc = ["base64/alloc"]
 js = ["getrandom/js"]
 
 [dependencies]
-blowfish = { version = "0.7", features = ["bcrypt"] }
+blowfish = { version = "0.8", features = ["bcrypt"] }
 getrandom = "0.2"
 base64 = { version = "0.13", default-features = false }
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add the following to Cargo.toml:
 bcrypt = "0.8"
 ```
 
-The minimum Rust version is 1.36.0.
+The minimum Rust version is 1.41.1.
 
 ## Usage
 The crate makes 3 things public: `DEFAULT_COST`, `hash`, `verify`.
@@ -48,7 +48,7 @@ for new projects.
 
 ## Changelog
 
-* 0.9.1: update blowfish to 0.8
+* 0.9.1: update blowfish to 0.8 and minimum Rust version to 1.41.1.
 * 0.9.0: update base64 to 0.13 and getrandom to 0.2
 * 0.8.2: fix no-std build
 * 0.8.0: constant time verification for hash, remove custom base64 code from repo and add `std` feature

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ for new projects.
 
 ## Changelog
 
+* 0.9.1: update blowfish to 0.8
 * 0.9.0: update base64 to 0.13 and getrandom to 0.2
 * 0.8.2: fix no-std build
 * 0.8.0: constant time verification for hash, remove custom base64 code from repo and add `std` feature


### PR DESCRIPTION
I've verified this doesn't change the minimum supported Rust version
of 1.36, given a suitable lockfile:

```
cargo +1.36 update --package regex --precise 1.4.6
cargo +1.36 update --package aho-corasick --precise 0.7.15
cargo +1.36 update --package memchr --precise 2.3.4
cargo +1.36 test
```

This will help me whittle down my duplicate deps; blowfish 0.9 uses cipher 0.3, which is the same as what salsa20 uses.