### PR TITLE
allow null bytes in inputs

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,7 +16,7 @@ pub enum BcryptError {
     #[cfg(feature = "std")]
     Io(io::Error),
     CostNotAllowed(u32),
-    InvalidPassword,
+    InvalidPassword, // no longer used
     InvalidCost(String),
     InvalidPrefix(String),
     InvalidHash(String),
@@ -52,7 +52,7 @@ impl fmt::Display for BcryptError {
                 crate::MAX_COST,
                 cost
             ),
-            BcryptError::InvalidPassword => write!(f, "Invalid password: contains NULL byte"),
+            BcryptError::InvalidPassword => write!(f, "Invalid password"),
             BcryptError::InvalidPrefix(ref prefix) => write!(f, "Invalid Prefix: {}", prefix),
             BcryptError::InvalidHash(ref hash) => write!(f, "Invalid hash: {}", hash),
             BcryptError::InvalidBase64(ref err) => write!(f, "Base64 error: {}", err),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,7 +16,6 @@ pub enum BcryptError {
     #[cfg(feature = "std")]
     Io(io::Error),
     CostNotAllowed(u32),
-    InvalidPassword, // no longer used
     InvalidCost(String),
     InvalidPrefix(String),
     InvalidHash(String),
@@ -52,7 +51,6 @@ impl fmt::Display for BcryptError {
                 crate::MAX_COST,
                 cost
             ),
-            BcryptError::InvalidPassword => write!(f, "Invalid password"),
             BcryptError::InvalidPrefix(ref prefix) => write!(f, "Invalid Prefix: {}", prefix),
             BcryptError::InvalidHash(ref hash) => write!(f, "Invalid hash: {}", hash),
             BcryptError::InvalidBase64(ref err) => write!(f, "Base64 error: {}", err),
@@ -68,7 +66,6 @@ impl error::Error for BcryptError {
             BcryptError::Io(ref err) => Some(err),
             BcryptError::InvalidCost(_)
             | BcryptError::CostNotAllowed(_)
-            | BcryptError::InvalidPassword
             | BcryptError::InvalidPrefix(_)
             | BcryptError::InvalidHash(_) => None,
             BcryptError::InvalidBase64(ref err) => Some(err),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,6 +273,26 @@ mod tests {
 
     #[test]
     fn can_verify_hash_generated_from_go() {
+        /*
+            package main
+            import (
+                "io"
+                "os"
+                "golang.org/x/crypto/bcrypt"
+            )
+            func main() {
+                buf, err := io.ReadAll(os.Stdin)
+                if err != nil {
+                    panic(err)
+                }
+                out, err := bcrypt.GenerateFromPassword(buf, bcrypt.MinCost)
+                if err != nil {
+                    panic(err)
+                }
+                os.Stdout.Write(out)
+                os.Stdout.Write([]byte("\n"))
+            }
+        */
         let binary_input = vec![
             29, 225, 195, 167, 223, 236, 85, 195, 114, 227, 7, 0, 209, 239, 189, 24, 51, 105, 124,
             168, 151, 75, 144, 64, 198, 197, 196, 4, 241, 97, 110, 135,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,9 +97,6 @@ fn _hash_password(password: &[u8], cost: u32, salt: &[u8]) -> BcryptResult<HashP
     if !(MIN_COST..=MAX_COST).contains(&cost) {
         return Err(BcryptError::CostNotAllowed(cost));
     }
-    if password.contains(&0u8) {
-        return Err(BcryptError::InvalidPassword);
-    }
 
     // Output is 24
     let mut output = [0u8; 24];
@@ -213,7 +210,6 @@ mod tests {
     use super::{
         _hash_password,
         alloc::{
-            format,
             string::{String, ToString},
             vec,
             vec::Vec,
@@ -273,6 +269,13 @@ mod tests {
     fn can_verify_hash_generated_from_node() {
         let hash = "$2a$04$n4Uy0eSnMfvnESYL.bLwuuj0U/ETSsoTpRT9GVk5bektyVVa5xnIi";
         assert!(verify("correctbatteryhorsestapler", hash).unwrap());
+    }
+
+    #[test]
+    fn can_verify_hash_generated_from_go() {
+        let binary_input = vec![29, 225, 195, 167, 223, 236, 85, 195, 114, 227, 7, 0, 209, 239, 189, 24, 51, 105, 124, 168, 151, 75, 144, 64, 198, 197, 196, 4, 241, 97, 110, 135];
+        let hash = "$2a$04$tjARW6ZON3PhrAIRW2LG/u9aDw5eFdstYLR8nFCNaOQmsH9XD23w.";
+        assert!(verify(binary_input, hash).unwrap());
     }
 
     #[test]
@@ -341,31 +344,38 @@ mod tests {
     }
 
     #[test]
-    fn forbid_null_bytes() {
-        fn assert_invalid_password(password: &[u8]) {
-            match hash(password, DEFAULT_COST) {
-                Ok(_) => panic!(
-                    "{}",
-                    format!(
-                        "NULL bytes must be forbidden, but {:?} is allowed.",
-                        password
-                    )
-                ),
-                Err(BcryptError::InvalidPassword) => {}
-                Err(e) => panic!(
-                    "{}",
-                    format!(
-                        "NULL bytes are forbidden but error differs: {} for {:?}.",
-                        e, password
-                    )
-                ),
+    fn allow_null_bytes() {
+        // hash p1, check the hash against p2:
+        fn hash_and_check(p1: &[u8], p2: &[u8]) -> Result<bool, BcryptError> {
+            let fast_cost = 4;
+            match hash(p1, fast_cost) {
+                Ok(s) => verify(p2, &s),
+                Err(e) => Err(e),
             }
         }
-        assert_invalid_password("\0".as_bytes());
-        assert_invalid_password("\0\0\0\0\0\0\0\0".as_bytes());
-        assert_invalid_password("passw0rd\0".as_bytes());
-        assert_invalid_password("passw0rd\0with tail".as_bytes());
-        assert_invalid_password("\0passw0rd".as_bytes());
+        fn assert_valid_password(p1: &[u8], p2: &[u8], expected: bool) {
+            match hash_and_check(p1, p2) {
+                Ok(checked) => {
+                    if checked != expected {
+                        panic!("checked {:?} against {:?}, incorrect result {}", p1, p2, checked)
+                    }
+                },
+                Err(e) => panic!("error evaluating password: {} for {:?}.", e, p1),
+            }
+        }
+
+        // bcrypt should consider all of these distinct:
+        let test_passwords = vec!["\0", "passw0rd\0", "password\0with tail", "\0passw0rd", "a", "a\0", "a\0b\0"];
+
+        for (i, p1) in test_passwords.iter().enumerate() {
+            for (j, p2) in test_passwords.iter().enumerate() {
+                assert_valid_password(p1.as_bytes(), p2.as_bytes(), i == j);
+            }
+        }
+
+        // this is a quirk of the bcrypt algorithm: passwords that are entirely null
+        // bytes hash to the same value, even if they are different lengths:
+        assert_valid_password("\0\0\0\0\0\0\0\0".as_bytes(), "\0".as_bytes(), true);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,10 @@ mod tests {
 
     #[test]
     fn can_verify_hash_generated_from_go() {
-        let binary_input = vec![29, 225, 195, 167, 223, 236, 85, 195, 114, 227, 7, 0, 209, 239, 189, 24, 51, 105, 124, 168, 151, 75, 144, 64, 198, 197, 196, 4, 241, 97, 110, 135];
+        let binary_input = vec![
+            29, 225, 195, 167, 223, 236, 85, 195, 114, 227, 7, 0, 209, 239, 189, 24, 51, 105, 124,
+            168, 151, 75, 144, 64, 198, 197, 196, 4, 241, 97, 110, 135,
+        ];
         let hash = "$2a$04$tjARW6ZON3PhrAIRW2LG/u9aDw5eFdstYLR8nFCNaOQmsH9XD23w.";
         assert!(verify(binary_input, hash).unwrap());
     }
@@ -357,15 +360,26 @@ mod tests {
             match hash_and_check(p1, p2) {
                 Ok(checked) => {
                     if checked != expected {
-                        panic!("checked {:?} against {:?}, incorrect result {}", p1, p2, checked)
+                        panic!(
+                            "checked {:?} against {:?}, incorrect result {}",
+                            p1, p2, checked
+                        )
                     }
-                },
+                }
                 Err(e) => panic!("error evaluating password: {} for {:?}.", e, p1),
             }
         }
 
         // bcrypt should consider all of these distinct:
-        let test_passwords = vec!["\0", "passw0rd\0", "password\0with tail", "\0passw0rd", "a", "a\0", "a\0b\0"];
+        let test_passwords = vec![
+            "\0",
+            "passw0rd\0",
+            "password\0with tail",
+            "\0passw0rd",
+            "a",
+            "a\0",
+            "a\0b\0",
+        ];
 
         for (i, p1) in test_passwords.iter().enumerate() {
             for (j, p2) in test_passwords.iter().enumerate() {


### PR DESCRIPTION
I'm the co-maintainer of [Ergo](https://github.com/ergochat/ergo), which preprocesses passwords with SHA3-512 and then hashes them with bcrypt. I got a report from a user that they were trying to produce a compatible implementation in Python, but couldn't because raw SHA3-512 output can contain null bytes, which weren't valid as inputs to pyca/bcrypt.

Here's my understanding of the problem:

1. There is in fact an algorithmic quirk of bcrypt where if two passwords consist entirely of null bytes, they will hash to the same value even if they are of different lengths
2. In general, however, there is no problem with null bytes as inputs to bcrypt, except in the case of bcrypt APIs that take a C-style `char *` as input, in which case the null byte will be taken as the end of the password. If one is "pre-hashing" inputs to bcrypt with an ordinary (fast) cryptographic hash function, there is no cryptographic reason to require a subsequent base64 encode step.

This change allows null bytes, adding some new test cases covering their handling. In support of the change:

1. https://crypto.stackexchange.com/questions/33335/why-does-0x00-make-bcrypt-weaker
2. The Go implementation, which allows null bytes: https://cs.opensource.google/go/x/crypto/+/86341886:bcrypt/bcrypt.go
3. #17 cites pyca/bcrypt's decision to reject null bytes as a justification for rejecting them here, but the maintainers of pyca/bcrypt have reconsidered this (as per discussion in https://github.com/pyca/bcrypt/pull/294 and https://github.com/pyca/bcrypt/pull/125)

Thanks very much for your time.