### PR TITLE
Overwrite allocated memory containing password

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ js = ["getrandom/js"]
 blowfish = { version = "0.9", features = ["bcrypt"] }
 getrandom = "0.2"
 base64 = { version = "0.13", default-features = false }
+zeroize = "1.5.4"
 
 [dev-dependencies]
 quickcheck = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
+use zeroize::Zeroize;
 
 use core::{fmt, str::FromStr};
 #[cfg(any(feature = "alloc", feature = "std"))]
@@ -109,6 +110,8 @@ fn _hash_password(password: &[u8], cost: u32, salt: &[u8]) -> BcryptResult<HashP
     let truncated = if vec.len() > 72 { &vec[..72] } else { &vec };
 
     bcrypt::bcrypt(cost, salt, truncated, &mut output);
+
+    vec.zeroize();
 
     Ok(HashParts {
         cost,


### PR DESCRIPTION
Overwrite the password copy done by rust-bcrypt with zeros.

Use [zeroize](https://crates.io/crates/zeroize) so it doesn't get optimized away.

[Openwall bcrypt](https://github.com/openwall/crypt_blowfish/blob/main/crypt_blowfish.c#L854) even hashes a dummy password after every real password hashed, to cleanse registers and (hopefully, might not work all the time) stack. Might be a bit over the top.