### PR TITLE
Added in method to hash using a base64 encoded salt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,17 +210,10 @@ pub fn hash_with_base64_salt<P: AsRef<[u8]>>(
 /// Verify that a password is equivalent to the hash provided
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn verify<P: AsRef<[u8]>>(password: P, hash: &str) -> BcryptResult<bool> {
-    use core::convert::TryInto;
-
     let parts = split_hash(hash)?;
-    let salt = base64::decode_config(&parts.salt, base64::BCRYPT)?;
-    let salt_len = salt.len();
-    let generated = _hash_password(
-        password.as_ref(),
-        parts.cost,
-        salt.try_into()
-            .map_err(|_| BcryptError::InvalidSaltLen(salt_len))?,
-    )?;
+
+    let generated = hash_with_base64_salt(password.as_ref(), parts.cost, &parts.salt)?;
+
     let source_decoded = base64::decode_config(&parts.hash, base64::BCRYPT)?;
     let generated_decoded = base64::decode_config(&generated.hash, base64::BCRYPT)?;
     if source_decoded.len() != generated_decoded.len() {


### PR DESCRIPTION
I found myself writing an application that received a salt that was already base64 encoded, and I needed to convert it into a byte array in order to hash it. This seemed a bit redundant, especially because there already was functionality to convert a base64 encoded salt into a byte array salt embedded in the verify function, so I pulled it out. I figured it might be useful to someone else too!