### PR TITLE
Use subtle Crate for constant-time comparison

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ blowfish = { version = "0.9", features = ["bcrypt"] }
 getrandom = "0.2"
 base64 = { version = "0.13", default-features = false }
 zeroize = { version = "1.5.4", optional = true }
+subtle = "2.4.1"
 
 [dev-dependencies]
 quickcheck = "1"


### PR DESCRIPTION
This change uses the [`subtle` Crate](https://docs.rs/subtle/2.4.1/subtle/) in order to perform constant-time comparison. Subtle goes through great lengths in order to prevent the compiler from optimizing away the constant-time behavior.

Edit to add: note that all tests pass, and the behavior of short-circuiting on differing lengths is maintained in `subtle`.

<details>
<pre>
running 20 tests
test tests::can_output_cost_and_salt_from_parsed_hash ... ok
test tests::can_split_hash ... ok
test tests::does_no_error_on_char_boundary_splitting ... ok
test tests::errors_with_a_hash_too_long ... ok
test tests::can_verify_hash_generated_from_go ... ok
test tests::can_verify_hash_generated_from_some_online_tool ... ok
test tests::a_wrong_password_is_false ... ok
test tests::errors_with_invalid_hash ... ok
test tests::errors_with_non_number_cost ... ok
test tests::invalid_hash_does_not_panic ... ok
test tests::can_verify_hash_generated_from_python ... ok
test tests::returns_an_error_if_a_parsed_hash_is_baddly_formated ... ok
test tests::can_verify_hash_generated_from_node ... ok
test tests::can_verify_own_generated ... ok
test tests::hash_with_fixed_salt ... ok
test tests::long_passwords_truncate_correctly ... ok
test tests::allow_null_bytes ... ok
test tests::can_verify_arbitrary_own_generated ... ok
test tests::doesnt_verify_different_passwords ... ok
test tests::generate_versions ... ok

test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.72s
</pre>
</details>
