### PR TITLE
Remove use_logging feature for quickcheck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ zeroize = { version = "1.5.4", optional = true }
 subtle = "2.4.1"
 
 [dev-dependencies]
-quickcheck = "1"
+# no default features avoid pulling in log
+quickcheck = { version = "1", default-features = false }
 
 [badges]
 maintenance = { status = "passively-maintained" }


### PR DESCRIPTION
Recent log 0.4.18 has a MSRV of 1.60. We don't need log so disable it and keep bcrypt's MSRV of 1.57.

This should fix the failure noted in #79 