### PR TITLE
Use feature "error_on_truncation" to send error on truncation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ default = ["std", "zeroize"]
 std = ["getrandom/std", "base64/std"]
 alloc = ["base64/alloc", "getrandom"]
 js = ["getrandom/js"]
+error_on_truncation = []
 
 [dependencies]
 blowfish = { version = "0.9", features = ["bcrypt"] }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,6 +27,7 @@ pub enum BcryptError {
     InvalidBase64(base64::DecodeError),
     #[cfg(any(feature = "alloc", feature = "std"))]
     Rand(getrandom::Error),
+    Truncation(usize),
 }
 
 macro_rules! impl_from_error {
@@ -69,6 +70,9 @@ impl fmt::Display for BcryptError {
             }
             #[cfg(any(feature = "alloc", feature = "std"))]
             BcryptError::Rand(ref err) => write!(f, "Rand error: {}", err),
+            BcryptError::Truncation(_) => {
+                write!(f, "Password longer than 72 bytes will be truncated")
+            }
         }
     }
 }
@@ -82,7 +86,8 @@ impl error::Error for BcryptError {
             | BcryptError::CostNotAllowed(_)
             | BcryptError::InvalidPrefix(_)
             | BcryptError::InvalidHash(_)
-            | BcryptError::InvalidSaltLen(_) => None,
+            | BcryptError::InvalidSaltLen(_)
+            | BcryptError::Truncation(_) => None,
             BcryptError::InvalidBase64(ref err) => Some(err),
             BcryptError::Rand(ref err) => Some(err),
         }


### PR DESCRIPTION
Per #87, this pull request adds a feature `error_on_truncation`. If enabled, `_hash_password` will return `BcryptError::Truncation` instead of proceeding with truncation. This feature is disabled by default for backwards compatibility.