### PR TITLE
Implement Display for HashParts instead of ToString directly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub enum Version {
 #[cfg(any(feature = "alloc", feature = "std"))]
 impl HashParts {
     /// Creates the bcrypt hash string from all its parts
-    fn format(self) -> String {
+    fn format(&self) -> String {
         self.format_for_version(Version::TwoB)
     }
 
@@ -84,9 +84,9 @@ impl FromStr for HashParts {
 }
 
 #[cfg(any(feature = "alloc", feature = "std"))]
-impl ToString for HashParts {
-    fn to_string(&self) -> String {
-        self.format_for_version(Version::TwoY)
+impl fmt::Display for HashParts {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.format())
     }
 }
 


### PR DESCRIPTION
The documentation for [ToString](https://doc.rust-lang.org/std/string/trait.ToString.html) states that

> ToString shouldn’t be implemented directly: Display should be implemented instead, and you get the ToString implementation for free.

The ToString implementation also used the old default version (2y). `HashParts::format()` can be called instead which uses the new default version (2b). This required changing `HashParts::format()` to take a reference to `self` instead of consuming it.

