### PR TITLE
Reject non-ASCII bytes in hash string to prevent panic (regression of #62)

### DIFF
--- a/fuzz/fuzz_targets/verify.rs
+++ b/fuzz/fuzz_targets/verify.rs
@@ -1,6 +1,10 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-fuzz_target!(|data: &[u8]| {
-    let _ = bcrypt::hash(&data, 4);
+fuzz_target!(|data: (&[u8], &str)| {
+    // Exercise the hash-string parser by feeding both arbitrary
+    // password bytes and arbitrary &str inputs to verify().
+    // The &str input is what reaches split_hash; this is the
+    // surface that #62 (and its regression) lived in.
+    let _ = bcrypt::verify(data.0, data.1);
 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,10 +190,12 @@ fn _hash_password(
 /// cost, salt and hash
 #[cfg(any(feature = "alloc", feature = "std"))]
 fn split_hash(hash: &str) -> BcryptResult<HashParts> {
-    // A valid bcrypt hash is always exactly 60 bytes:
-    if hash.len() != 60 {
+    // A valid bcrypt hash is always exactly 60 ASCII bytes. Rejecting
+    // non-ASCII up front avoids panics from `&str` slicing through the
+    // middle of a multi-byte UTF-8 character (regression of #62).
+    if hash.len() != 60 || !hash.is_ascii() {
         return Err(BcryptError::InvalidHash(
-            "the hash format is malformed; expected 60 bytes",
+            "the hash format is malformed; expected 60 ASCII bytes",
         ));
     }
 
@@ -747,5 +749,31 @@ mod tests {
             &[],
             "2a$$$0$OOOOOOOOOOOOOOOOOOOOO£OOOOOOOOOOOOOOOOOOOOOOOOOOOOOO",
         );
+    }
+
+    #[test]
+    fn verify_rejects_multibyte_utf8_in_hash() {
+        // Constructed so byte position 22 falls inside the multi-byte
+        // sequence for '£' (0xC2 0xA3). Before this fix, this hash would
+        // panic in str::slice_error_fail when split_hash sliced
+        // &salt_and_hash[..22]. After: returns InvalidHash, like every
+        // other malformed input. Regression test for #62.
+        let hash = "$2b$04$aaaaaaaaaaaaaaaaaaaaa£aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        assert_eq!(hash.len(), 60); // sanity: byte length is still 60
+        assert!(matches!(
+            verify(&b"password"[..], hash),
+            Err(BcryptError::InvalidHash(_))
+        ));
+    }
+
+    #[test]
+    fn split_hash_rejects_non_ascii() {
+        // Direct parser-level test of the invariant: any non-ASCII byte
+        // anywhere in a 60-byte hash string is rejected up front.
+        let hash = "$2b$04$aaaaaaaaaaaaaaaaaaaaa£aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        assert!(matches!(
+            split_hash(hash),
+            Err(BcryptError::InvalidHash(_))
+        ));
     }
 }


### PR DESCRIPTION
Per private email discussion with @Keats — opening this as a regular bug fix.

## Summary

`bcrypt::verify` / `HashParts::from_str` panic in `str::slice_error_fail` 
when given a 60-byte `&str` containing a multi-byte UTF-8 character at 
certain positions. This is a regression of the fix shipped in 2021 for 
issue #62 (commit `0833509`), which was lost during the parser rewrite 
in PR #95 (`e9a8394`, released as 0.19.0).

## Root cause

`split_hash` performs five `&str` slicing operations on the input:
`&hash[1..3]`, `&hash[4..6]`, `&hash[7..]`, `&salt_and_hash[..22]`, and 
`&salt_and_hash[22..]`. None of these are boundary-checked. Any input 
where a multi-byte UTF-8 character spans one of those boundaries panics.

The previous parser had an `is_char_boundary(22)` guard. After the rewrite, 
the existing regression test `does_no_error_on_char_boundary_splitting` 
still exists but is rejected earlier by the new `bytes[0] != b'$'` check 
and never actually reaches the buggy slices — which is why CI was green 
on the regression.

## Fix

Reject non-ASCII bytes in the hash string up front in `split_hash`. A 
valid bcrypt hash is always 60 ASCII bytes, so this closes the entire 
class rather than guarding each slice individually.

## Tests

Two new tests added (both fail on `master`, pass with this change):

- `verify_rejects_multibyte_utf8_in_hash` — end-to-end via `verify()`
- `split_hash_rejects_non_ascii` — direct parser-level assertion

The pre-existing `does_no_error_on_char_boundary_splitting` test is 
kept as-is.

## Bonus: fuzz target was misnamed

`fuzz/fuzz_targets/verify.rs` was calling `bcrypt::hash` instead of 
`bcrypt::verify`, so the hash-string parser surface was never actually 
fuzzed. Fixed in the second commit. With the fix, future regressions 
of this class should be caught by coverage-guided fuzzing.

## Affects

- 0.19.0 — yes
- 0.19.1 — yes (current)
- 0.18.0 and earlier — no